### PR TITLE
Fix loss functions

### DIFF
--- a/theseus/classification/losses/ce_loss.py
+++ b/theseus/classification/losses/ce_loss.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, Optional
 import torch
 from torch import nn
-from timm.loss import LabelSmoothingCrossEntropy
+from timm.loss import LabelSmoothingCrossEntropy, SoftTargetCrossEntropy
 from theseus.utilities.cuda import move_to
 
 class CELoss(nn.Module):
@@ -28,12 +28,16 @@ class SmoothCELoss(nn.Module):
 
     def __init__(self, smoothing: float=0.1, **kwargs):
         super(SmoothCELoss, self).__init__(**kwargs)
-        self.criterion = LabelSmoothingCrossEntropy(smoothing=smoothing)
+        self.smooth_criterion = LabelSmoothingCrossEntropy(smoothing=smoothing)
+        self.soft_criterion = SoftTargetCrossEntropy()
 
     def forward(self, outputs: Dict[str, Any], batch: Dict[str, Any], device: torch.device):
         pred = outputs['outputs']
         target = move_to(batch["targets"], device)
 
-        loss = self.criterion(pred, target.view(-1).contiguous())
+        if pred.shape == target.shape:
+            loss = self.soft_criterion(pred, target)
+        else:
+            loss = self.smooth_criterion(pred, target.view(-1).contiguous())
         loss_dict = {"CE": loss.item()}
         return loss, loss_dict

--- a/theseus/classification/losses/focal_loss.py
+++ b/theseus/classification/losses/focal_loss.py
@@ -18,8 +18,9 @@ class FocalLoss(nn.Module):
         num_classes = outputs.shape[-1]
 
         # Need to be one hot encoding
-        targets = nn.functional.one_hot(targets, num_classes=num_classes)
-        targets = targets.float().squeeze()
+        if outputs.shape != targets.shape:
+            targets = nn.functional.one_hot(targets, num_classes=num_classes)
+            targets = targets.float().squeeze()
 
         loss = sigmoid_focal_loss(outputs, targets, self.alpha, self.gamma, self.reduction)
         loss_dict = {"L": loss.item()}


### PR DESCRIPTION
- Fix FocalLoss, SmoothCELoss when using with MixupCutmixCollator. This error happens because these two losses required one-hot encoding.
- Resolves #26 