### PR TITLE
add a rename param for download_from_wandb

### DIFF
--- a/theseus/base/utilities/download.py
+++ b/theseus/base/utilities/download.py
@@ -68,6 +68,7 @@ def download_from_wandb(filename, run_path, save_dir, rename=None, generate_id_t
     
     try:
         path = wandb.restore(filename, run_path=run_path, root=save_dir)
+        LOGGER.text("Successfully download {} from wandb run path {}".format(filename, run_path), level=LoggerObserver.INFO)
         
         # Save run id to wandb_id.txt
         if generate_id_text_file:
@@ -76,14 +77,14 @@ def download_from_wandb(filename, run_path, save_dir, rename=None, generate_id_t
                 f.write(wandb_id)
         
         if rename:
-            new_name = str(Path(path.name).parent / rename)
-            os.rename(path.name, new_name)
+            new_name = str(Path(path.name).resolve().parent / rename)
+            os.rename(Path(path.name).resolve(), new_name)
+            LOGGER.text("Saved to {}".format(new_name), level=LoggerObserver.INFO)
             return new_name
         
-        # These 2 lines do not show on the terminal
-        LOGGER.text("Successfully download {} from wandb path {}".format(filename, run_path), level=LoggerObserver.INFO)
-        LOGGER.text("Saved to {}".format(save_dir), level=LoggerObserver.INFO)
+        
+        LOGGER.text("Saved to {}".format((Path(save_dir) / path.name).resolve()), level=LoggerObserver.INFO)
         return path.name
     except:
-        LOGGER.text("Failed to download from wandb.", level=LoggerObserver.ERROR)
+        LOGGER.text("Failed to download from wandb.\nException {}".format(e), level=LoggerObserver.ERROR)
         return None

--- a/theseus/base/utilities/download.py
+++ b/theseus/base/utilities/download.py
@@ -86,5 +86,5 @@ def download_from_wandb(filename, run_path, save_dir, rename=None, generate_id_t
         LOGGER.text("Saved to {}".format((Path(save_dir) / path.name).resolve()), level=LoggerObserver.INFO)
         return path.name
     except:
-        LOGGER.text("Failed to download from wandb.\nException {}".format(e), level=LoggerObserver.ERROR)
+        LOGGER.text("Failed to download from wandb.", level=LoggerObserver.ERROR)
         return None

--- a/theseus/base/utilities/download.py
+++ b/theseus/base/utilities/download.py
@@ -3,6 +3,8 @@ import os.path as osp
 import urllib.request as urlreq
 
 import gdown
+import os
+from pathlib import Path
 
 from theseus.base.utilities.loggers.observer import LoggerObserver
 
@@ -60,18 +62,27 @@ def download_from_url(url, root=None, filename=None):
     return fpath
 
 
-def download_from_wandb(filename, run_path, save_dir, generate_id_text_file=False):
-    import wandb
+def download_from_wandb(filename, run_path, save_dir, rename=None, generate_id_text_file=False):
 
+    import wandb
+    
     try:
         path = wandb.restore(filename, run_path=run_path, root=save_dir)
-
+        
         # Save run id to wandb_id.txt
         if generate_id_text_file:
             wandb_id = osp.basename(run_path)
             with open(osp.join(save_dir, "wandb_id.txt"), "w") as f:
                 f.write(wandb_id)
-
+        
+        if rename:
+            new_name = str(Path(path.name).parent / rename)
+            os.rename(path.name, new_name)
+            return new_name
+        
+        # These 2 lines do not show on the terminal
+        LOGGER.text("Successfully download {} from wandb path {}".format(filename, run_path), level=LoggerObserver.INFO)
+        LOGGER.text("Saved to {}".format(save_dir), level=LoggerObserver.INFO)
         return path.name
     except:
         LOGGER.text("Failed to download from wandb.", level=LoggerObserver.ERROR)


### PR DESCRIPTION
An example python file 
```
import argparse
from theseus.base.utilities.download import download_from_wandb
from theseus.base.utilities.loggers.observer import LoggerObserver

LOGGER = LoggerObserver.getLogger("main")

if __name__ == "__main__":
    parser = argparse.ArgumentParser()
    parser.add_argument('--filename', type=str, help='most of the time is checkpoints/best.pth')
    parser.add_argument('--run_path', type=str, help='model path on WANDB server')
    parser.add_argument('--save_dir', type=str, help='the directory to save the weight', nargs='+', default=".")
    parser.add_argument('--rename',   type=str, help='the new name for the weight')
    opt = parser.parse_args()
    
    download_from_wandb(
        filename=opt.filename,
        run_path=opt.run_path,
        save_dir=opt.save_dir,
        rename=opt.rename # File extension required
    )
```